### PR TITLE
Removed some commented out code and a bad comment that started with ## 

### DIFF
--- a/public_html/webclient2/locale/default/en/search.po
+++ b/public_html/webclient2/locale/default/en/search.po
@@ -6,8 +6,6 @@ msgid "search"
 msgstr "search"
 
 # header
-#msgid "Showing %1 - %2 out of %3 results"
-#msgstr "Showing %1 - %2 out of %3 results"
 
 msgid "(search_btn_img)"
 msgstr "img/default/search_en.jpg"
@@ -143,7 +141,8 @@ msgid "(cacheinfo)"
 msgstr "This is the local copy of the document, as stored on the search system at this moment."
 
 
-## Navigation
+# Navigation
+
 # Attribute description
 msgid "SharePoint"
 msgstr "SharePoint"


### PR DESCRIPTION
Some PO editors has issues with code that is commented out if there also is msgid/msgstr in the comment. Some goes for comment that starts with ##.
